### PR TITLE
Minor changes and bug fixes and adding .NET CORE 2.0 support

### DIFF
--- a/DockerSecretsConfigurationBuilderExtensions.cs
+++ b/DockerSecretsConfigurationBuilderExtensions.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.Extensions.Configuration
 {
-    using System;
     using Microsoft.Extensions.Configuration.DockerSecrets;
+    using System;
 
     /// <summary>
     /// Extension methods for registering <see cref="DockerSecretsConfigurationProvider"/> with <see cref="IConfigurationBuilder"/>.
@@ -40,6 +40,18 @@ namespace Microsoft.Extensions.Configuration
             });
 
         /// <summary>
+        /// Adds the docker secrets.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="optional">if set to <c>true</c> [optional].</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddDockerSecrets(this IConfigurationBuilder builder, bool optional)
+            => builder.AddDockerSecrets(source =>
+            {
+                source.Optional = optional;
+            });
+
+        /// <summary>
         /// Adds a docker secrets configuration source to <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
@@ -47,19 +59,5 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddDockerSecrets(this IConfigurationBuilder builder, Action<DockerSecretsConfigurationSource> configureSource)
             => builder.Add(configureSource);
-
-        /// <summary>
-        /// Adds a new configuration source.
-        /// </summary>
-        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="configureSource">Configures the source secrets.</param>
-        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        private static IConfigurationBuilder Add<TSource>(this IConfigurationBuilder builder, Action<TSource> configureSource)
-           where TSource : IConfigurationSource, new()
-        {
-            var source = new TSource();
-            configureSource?.Invoke(source);
-            return builder.Add(source);
-        }
     }
 }

--- a/DockerSecretsConfigurationSource.cs
+++ b/DockerSecretsConfigurationSource.cs
@@ -1,7 +1,8 @@
+
 namespace Microsoft.Extensions.Configuration.DockerSecrets
 {
+    using FileProviders;
     using System;
-    using Microsoft.Extensions.FileProviders;
 
     /// <summary>
     /// An <see cref="ConfigurationProvider"/> for docker secrets.
@@ -20,6 +21,14 @@ namespace Microsoft.Extensions.Configuration.DockerSecrets
         /// The secrets directory which will be used if FileProvider is not set.
         /// </summary>
         public string SecretsDirectory { get; set; } = "/run/secrets";
+
+        /// <summary>
+        /// Gets or sets the docker secrets word separator.
+        /// </summary>
+        /// <value>
+        /// The docker secrets word separator.
+        /// </value>
+        public string DockerSecretsWordSeparator { get; set; } = "__";
 
         /// <summary>
         /// The FileProvider representing the secrets directory.

--- a/Microsoft.Extensions.Configuration.DockerSecrets.Unofficial.csproj
+++ b/Microsoft.Extensions.Configuration.DockerSecrets.Unofficial.csproj
@@ -1,22 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <Description>Configuration providers that work with docker secrets for Microsoft.Extensions.Configuration. The official package is not yet available, this is an unnoficial version that we can use until it is released officially.</Description>
     <PackageTags>configuration;docker</PackageTags>
-    <Version>1.1.2</Version>
+    <Version>2.0.0</Version>
     <Authors>Muhammad Rehan Saeed (RehanSaeed.com)</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile></DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Change NormalizeKey to make DockerSecretsWordSeparator optional. It…
is possible that not all appsettings variables will be inside of an json "object". In that case you will not need a separator
- Slight reorganization of the code to include less if/elses
- Fixed a bug where if there are no secrets in the directory and optional, to return.
- In DockerSecretsConfigurationProvider, the DOTNET Property Source changed to a readonly variable. This wont need to change.
- Added a function to AddDockerSecrets that accepts optional only.
- Added comments